### PR TITLE
Issue #1: VCF filter autocomplete not picking up users.

### DIFF
--- a/includes/vcf_filter.admin.inc
+++ b/includes/vcf_filter.admin.inc
@@ -333,7 +333,7 @@ function vcf_filter_admin_vcf_file_perm_form($form, &$form_state) {
   $form['user']['add']['form_element'] = array(
     '#type' => 'textfield',
     '#title' => 'User to give permission to',
-    '#autocomplete_path' => 'user/autocomplete',
+    '#autocomplete_path' => 'autocomplete/vcf_filter/user',
   );
 
   $form['user']['add']['submit'] = array(
@@ -455,4 +455,19 @@ function vcf_filter_admin_form_perm_table($vars) {
   }
 
   return theme('table', $table);
+}
+
+/**
+ * Autocomplete: Usernames in VCF Access permissions.
+ */
+function vcf_filter_user_autocomplete($string = '') {
+  $matches = array();
+  if ($string) {
+    $result = db_query('SELECT name FROM {users} WHERE name~:string', array(':string' => $string));
+    foreach ($result as $user) {
+      $matches[$user->name] = check_plain($user->name);
+    }
+  }
+
+  drupal_json_output($matches);
 }

--- a/includes/vcf_filter.admin.inc
+++ b/includes/vcf_filter.admin.inc
@@ -463,7 +463,7 @@ function vcf_filter_admin_form_perm_table($vars) {
 function vcf_filter_user_autocomplete($string = '') {
   $matches = array();
   if ($string) {
-    $result = db_query('SELECT name FROM {users} WHERE name~:string', array(':string' => $string));
+    $result = db_query('SELECT name FROM {users} WHERE LOWER(name) ~ LOWER(:string)', array(':string' => $string));
     foreach ($result as $user) {
       $matches[$user->name] = check_plain($user->name);
     }

--- a/vcf_filter.module
+++ b/vcf_filter.module
@@ -118,6 +118,17 @@ function vcf_filter_menu() {
     'file' => 'includes/vcf_filter.admin.inc',
   );
 
+  // AUTOCOMPLETE: User
+  // Note: We can't just use user/autocomplete, user_autocomplete() because it assumes
+  // you are typing the username in order rather then simply finding the substring.
+  $items['autocomplete/vcf_filter/user'] = array(
+    'title' => 'VCF Filter: Autocomplete',
+    'page callback' => 'vcf_filter_user_autocomplete',
+    'type' => MENU_CALLBACK,
+    'access arguments' => array('administer tripal'),
+    'file' => 'includes/vcf_filter.admin.inc',
+  );
+
   return $items;
 }
 


### PR DESCRIPTION
This pull request addresses Issue #1.

## Description of Bug
VCF Filter was originally just using the Drupal user autocomplete. However, it turns out this autocomplete assumes you were going to type the user name starting with the first letter. User assumptions were that it would search based on any substring.

## Fixed
This bug was fixed by simply creating our own autocomplete that matched user expectation.

## How to Test
To test navigate to Administration menu > Tripal > Extensions > VCF Filter. Then for any file, select "access" under operations. Then under "user permissions" type any username in the "User to give permission to" autocomplete. It should autocomplete the users name ignoring whether your substring is at the beginning of the name and being case insensitive.