### PR TITLE
Addresses issue #3: ABH format assumes non-missing, polymorphic SNPs between parents

### DIFF
--- a/includes/vcf_filter.form.inc
+++ b/includes/vcf_filter.form.inc
@@ -162,9 +162,9 @@ function vcf_filter_form($form, &$form_state) {
   );
   $options = array(
     'abh' => array(
-      'name' => 'A/B Format',
+      'name' => 'ABH Format',
       'has_quality' => 'No',
-      'description' => 'Alleles are coded as A/B based on the parents. This format is only suitable for biparental crosses',
+      'description' => 'Alleles are coded as A if they match the maternal parent, B based on the paternal parent, whereas H represents a heterozygous call and "-" as missing. <br><strong>NOTE:</strong> This format is only suitable for biparental crosses and any SNPs in which the parents are missing, heterozygous, or the same genotypic call will be <strong>excluded</strong>!',
     ),
     /*
     'matrix' => array(

--- a/includes/vcf_filter.trpdownload.abh.inc
+++ b/includes/vcf_filter.trpdownload.abh.inc
@@ -159,7 +159,6 @@ function vcf_filter_convert_VCF_to_ABH($input_file, $maternal_parent, $paternal_
     // Check the number of alleles that we have - we don't know how to handle multiple
     // alleles within a bi-parental population at this point.
     $alt_alleles = $marker['ALT'];
-    print "Ref allele: " . $marker['REF'] . " , Alt Allele(s): " . $alt_alleles . "\n";
     if (preg_match('/,/', $alt_alleles)) {
       print "Skipping site: ( $chrom $pos ) due to multiple alternate alleles: $alt_alleles\n";
       continue;

--- a/includes/vcf_filter.trpdownload.abh.inc
+++ b/includes/vcf_filter.trpdownload.abh.inc
@@ -156,6 +156,14 @@ function vcf_filter_convert_VCF_to_ABH($input_file, $maternal_parent, $paternal_
     $chrom = $marker['#CHROM'];
     $pos = $marker['POS'];
 
+    // Check the number of alleles that we have - we don't know how to handle multiple
+    // alleles within a bi-parental population at this point.
+    $alt_alleles = $marker['ALT'];
+    print "Ref allele: " . $marker['REF'] . " , Alt Allele(s): " . $alt_alleles . "\n";
+    if (preg_match('/,/', $alt_alleles)) {
+      print "Skipping site: ( $chrom $pos ) due to multiple alternate alleles: $alt_alleles\n";
+      continue;
+    }
     $converted_line = array($chrom, $pos);
 
     foreach ($sample_names as $current_sample) {

--- a/includes/vcf_filter.trpdownload.abh.inc
+++ b/includes/vcf_filter.trpdownload.abh.inc
@@ -176,22 +176,30 @@ function vcf_filter_convert_VCF_to_ABH($input_file, $maternal_parent, $paternal_
           // The maternal parent is missing a genotype, thus skip this site completely
           print "Skipping site: ( $chrom $pos ) due to missing call in $maternal_parent\n";
           continue 2;
-        } else if (($genotype_calls[0] !== $genotype_calls[1])) {
+        }
+        else if (($genotype_calls[0] !== $genotype_calls[1])) {
           // The maternal parent must be heterozygous, also skip this site.
-          print "Skipping at site: $chrom $pos due to a heterozygous call in $maternal_parent\n";
+          print "Skipping site: ( $chrom $pos ) due to a heterozygous call in $maternal_parent\n";
           continue 2;
         }
         $maternal_genotype = $genotype_calls;
         array_push($converted_line, "A");
         continue;
-      } else if (strcmp($current_sample, $paternal_parent) === 0) {
+      }
+      else if (strcmp($current_sample, $paternal_parent) === 0) {
         if (($genotype_calls[0] === '.') || ($genotype_calls[1] === '.')) {
           // The paternal parent is missing a genotype, thus skip this site completely
           print "Skipping site: ( $chrom $pos ) due to missing call in $paternal_parent\n";
           continue 2;
-        } else if (($genotype_calls[0] !== $genotype_calls[1])) {
+        }
+        else if (($genotype_calls[0] !== $genotype_calls[1])) {
           // The paternal parent must be heterozygous, also skip this site.
-          print "Skipping at site: $chrom $pos due to a heterozygous call in $paternal_parent\n";
+          print "Skipping site: ( $chrom $pos ) due to a heterozygous call in $paternal_parent\n";
+          continue 2;
+        }
+        else if (($genotype_calls === $maternal_genotype)) {
+          // Dad has the same genotype as Mom? That can't be right. Skip this too.
+          print "Skipping site: ( $chrom $pos ) due to parents having matching genotype: $genotype_calls[0]/$genotype_calls[1]\n";
           continue 2;
         }
         $paternal_genotype = $genotype_calls;
@@ -207,16 +215,28 @@ function vcf_filter_convert_VCF_to_ABH($input_file, $maternal_parent, $paternal_
       if ($genotype_calls[0] == $maternal_genotype[0]) {
         if ($genotype_calls[1] == $maternal_genotype[1]) {
           array_push($converted_line, "A");
-        } else if ($genotype_calls[1] == $paternal_genotype[1]) {
+        }
+        else if ($genotype_calls[1] == $paternal_genotype[1]) {
           array_push($converted_line, "H");
-        } else { array_push($converted_line, "-"); }
-      } else if ($genotype_calls[0] == $paternal_genotype[0]) {
+        }
+        else {
+          array_push($converted_line, "-");
+        }
+      }
+      else if ($genotype_calls[0] == $paternal_genotype[0]) {
         if ($genotype_calls[1] == $paternal_genotype[1]) {
           array_push($converted_line, "B");
-        } else if ($genotype_calls[1] == $maternal_genotype[1]) {
+        }
+        else if ($genotype_calls[1] == $maternal_genotype[1]) {
           array_push($converted_line, "H");
-        } else { array_push($converted_line, "-"); }
-      } else { array_push($converted_line, "-"); }
+        }
+        else {
+          array_push($converted_line, "-");
+        }
+      }
+      else {
+        array_push($converted_line, "-");
+      }
     }
 
     // And print it to the output file!


### PR DESCRIPTION
## Description of Bug
Previously, the function to convert a filtered VCF to ABH format assumed all SNPs were bi-allelic, and the parents were non-missing, non-heterozygous and polymorphic. Sadly, this is often not the case!

## Fixed
My previous commit on master (cc808c4) addressed when parental calls were missing or heterozygous. I then addressed identical parental calls by adding an additional check to compare with the maternal call, after checking if the paternal call is missing or het (Commit: ecb7de0f2df0cbd1365a1fc35124ed48967f8b02). To skip sites with more than two alleles, I simply checked for a comma in the ALT column of the VCF (Commit: 11be5b0c250e6ab5a769c81e3fa2963f17129dc3). Finally, I attempted to clarify the description of the ABH format (name changed from A/B to ABH btw!) to the user so that anyone selecting the format is aware that SNPs may be excluded from their file (Commit: 91ce291590de1a51e4ad1e3e6aa19861b669549a)

## How to test
You can follow my suggestions from issue #3 for testing. I have also uploaded a small VCF file to fresh which I called "Carolyn's Test VCF" which may be more manageable to manipulate. If you'd like, you can suggest to me some scenarios you'd like to test, I can alter the file, and then you can download it in ABH and look at the output of the file and the tripal job to verify it was filtered correctly.