### PR TITLE
9 bgzip vcf download

### DIFF
--- a/includes/vcf_filter.form.inc
+++ b/includes/vcf_filter.form.inc
@@ -183,10 +183,10 @@ function vcf_filter_form($form, &$form_state) {
       'has_quality' => 'Yes',
       'description' => 'A variant by germplasm matrix with each cell containing a combination of SNP call and quality information. See the '.l('Specification', 'http://samtools.github.io/hts-specs/VCFv4.2.pdf').' for more information.',
     ),
-	'bgzipped' => array(
+    'bgzipped' => array(
       'name' => 'Bgzipped VCF',
       'has_quality' => 'Yes',
-      'description' => 'An archive file which contains a Tabix file from filtered VCF and an index file, for use with an R package called VariantAnnotation. ',
+      'description' => 'An archive containing a bgzipped VCF file and a Tabix file. This combination is required by various programs such as the R package VariantAnnotation. See the '.l('tabix manual','http://www.htslib.org/doc/tabix.html').' for more information.',
     ),
   );
   $form['s3']['format'] = array(
@@ -279,7 +279,7 @@ function vcf_filter_form_submit($form, &$form_state) {
     'abh' => '/filter_vcf/ABH',
     'matrix' => '/filter_vcf/SNP-Matrix',
     'qual_matrix' => '/filter_vcf/Quality-Matrix',
-	'bgzipped' => '/filter_vcf/Bgzipped',
+    'bgzipped' => '/filter_vcf/Bgzipped',
     'vcf' => '/filter_vcf/VCF'
   );
   $form_state['redirect'] = array(

--- a/includes/vcf_filter.form.inc
+++ b/includes/vcf_filter.form.inc
@@ -183,6 +183,11 @@ function vcf_filter_form($form, &$form_state) {
       'has_quality' => 'Yes',
       'description' => 'A variant by germplasm matrix with each cell containing a combination of SNP call and quality information. See the '.l('Specification', 'http://samtools.github.io/hts-specs/VCFv4.2.pdf').' for more information.',
     ),
+	'bgzipped' => array(
+      'name' => 'Bgzipped VCF',
+      'has_quality' => 'Yes',
+      'description' => 'An archive file which contains a Tabix file from filtered VCF and an index file, for use with an R package called VariantAnnotation. ',
+    ),
   );
   $form['s3']['format'] = array(
     '#type' => 'tableselect',
@@ -274,6 +279,7 @@ function vcf_filter_form_submit($form, &$form_state) {
     'abh' => '/filter_vcf/ABH',
     'matrix' => '/filter_vcf/SNP-Matrix',
     'qual_matrix' => '/filter_vcf/Quality-Matrix',
+	'bgzipped' => '/filter_vcf/Bgzipped',
     'vcf' => '/filter_vcf/VCF'
   );
   $form_state['redirect'] = array(

--- a/includes/vcf_filter.trpdownload.bgzipped.inc
+++ b/includes/vcf_filter.trpdownload.bgzipped.inc
@@ -50,34 +50,33 @@ function vcf_filter_bgzipped_generate_file($variables, $job_id = NULL) {
   //===============
   drush_print("\nConversion from VCF to bgzipped VCF Format.");
 
-  $bgzip_filename = preg_replace('/\\.[^.\\s]{3,4}$/', '', $variables['filename']);
+  //remove the extension of filename we can obtain from $variables
+  //since we know the extension is always '.vcf', to be safe, no longer need to remove last 3,4 characters
+  //$bgzip_filename = preg_replace('/\\.[^.\\s]{3,4}$/', '', $variables['filename']);
+  $bgzip_filename = preg_replace('/\.vcf$/', '', $variables['filename']);
   
   $format_tmp = variable_get('file_temporary_path') . '/' . $bgzip_filename;
   $outfile = $format_tmp . '.tar';
-  drush_print(str_repeat('-', 60));
   
-  /*Creating a compressed and indexed VCF
-    bgzip -c file.vcf > file.vcf.gz
-    tabix -p vcf file.vcf.gz
-    tar cvf archive.tar file.vcf.gz file.vcf.gz.tbi
+  /*Creating a compressed and indexed VCF in 3 steps
+    1. bgzip -c file.vcf > file.vcf.gz
+    2. tabix -p vcf file.vcf.gz
+    3. tar cvf archive.tar file.vcf.gz file.vcf.gz.tbi
   */
-  //$command = 'vcftools --vcf ' . escapeshellarg($filtered_vcf) . ' --geno-depth --out ' . escapeshellarg($format_tmp);
-  
+ 
   $bgzip_tmp_path = variable_get('file_temporary_path');
   
+  drush_print('Useing bgzip to generate bgzip file: '.$format_tmp.'.gz');
   $command = 'bgzip -c ' . escapeshellarg($filtered_vcf) . ' > ' . escapeshellarg($format_tmp) . '.gz';
   drush_print(shell_exec($command));
-  drush_print(str_repeat('-', 60));
-  drush_print('File generated is: '.$format_tmp.'.gz');
   
+  drush_print('Useing tabix to generate index file: '.$format_tmp.'.gz.tbi');
   $command = 'tabix -p vcf ' . escapeshellarg($format_tmp) . '.gz';
   drush_print(shell_exec($command));
-  drush_print(str_repeat('-', 60));
-  drush_print('File generated is: '.$format_tmp.'.gz.tbi');
+  
+  drush_print('Combining into an archive: '.$format_tmp.'.tar');
   $command = 'tar cvf '.escapeshellarg($format_tmp).'.tar'.' -C '.escapeshellarg($bgzip_tmp_path).' '.escapeshellarg($bgzip_filename).'.gz '.escapeshellarg($bgzip_filename).'.gz.tbi';
   drush_print(shell_exec($command));
-  drush_print(str_repeat('-', 60));
-  drush_print('File generated is: '.$format_tmp.'tar');
   
   if (!file_exists($outfile)) {
     drush_set_error("ERROR: Unable to convert VCF file to an archive file (.tar).");
@@ -85,14 +84,16 @@ function vcf_filter_bgzipped_generate_file($variables, $job_id = NULL) {
   }
   
   // Tell the user we're almost there!
-  tripal_set_job_progress($job_id, 90);                                                                                          
+  tripal_set_job_progress($job_id, 90);  
+  
   drush_print("\nMove Formatted file to the name we expect.");
   shell_exec("mv $format_tmp.tar $filepath");
+  
   if (!file_exists($filepath)) {
     drush_set_error("ERROR: Unable to move Filtered VCF into expected file director: $filepath");
     exit(5); // We use exit to trigger a Tripal job error b/c Tripal doesn't check the return code :-(.
   }
   // Done!
- tripal_set_job_progress($job_id, 100);
+  tripal_set_job_progress($job_id, 100);
 }
   

--- a/includes/vcf_filter.trpdownload.bgzipped.inc
+++ b/includes/vcf_filter.trpdownload.bgzipped.inc
@@ -53,7 +53,7 @@ function vcf_filter_bgzipped_generate_file($variables, $job_id = NULL) {
   //remove the extension of filename we can obtain from $variables
   //since we know the extension is always '.vcf', to be safe, no longer need to remove last 3,4 characters
   //$bgzip_filename = preg_replace('/\\.[^.\\s]{3,4}$/', '', $variables['filename']);
-  $bgzip_filename = preg_replace('/\.vcf$/', '', $variables['filename']);
+  $bgzip_filename = preg_replace('/\.tar$/', '', $variables['filename']);
   
   $format_tmp = variable_get('file_temporary_path') . '/' . $bgzip_filename;
   $outfile = $format_tmp . '.tar';

--- a/includes/vcf_filter.trpdownload.bgzipped.inc
+++ b/includes/vcf_filter.trpdownload.bgzipped.inc
@@ -49,34 +49,43 @@ function vcf_filter_bgzipped_generate_file($variables, $job_id = NULL) {
   // FORMAT.
   //===============
   drush_print("\nConversion from VCF to bgzipped VCF Format.");
-  $format_tmp = variable_get('file_temporary_path') . '/' . uniqid();
+
+  $bgzip_filename = preg_replace('/\\.[^.\\s]{3,4}$/', '', $variables['filename']);
+  
+  $format_tmp = variable_get('file_temporary_path') . '/' . $bgzip_filename;
   $outfile = $format_tmp . '.tar';
-  drush_print('Converted results will be in: '.$outfile);
   drush_print(str_repeat('-', 60));
+  
   /*Creating a compressed and indexed VCF
     bgzip -c file.vcf > file.vcf.gz
     tabix -p vcf file.vcf.gz
     tar cvf archive.tar file.vcf.gz file.vcf.gz.tbi
   */
   //$command = 'vcftools --vcf ' . escapeshellarg($filtered_vcf) . ' --geno-depth --out ' . escapeshellarg($format_tmp);
+  
+  $bgzip_tmp_path = variable_get('file_temporary_path');
+  
   $command = 'bgzip -c ' . escapeshellarg($filtered_vcf) . ' > ' . escapeshellarg($format_tmp) . '.gz';
   drush_print(shell_exec($command));
   drush_print(str_repeat('-', 60));
+  drush_print('File generated is: '.$format_tmp.'.gz');
+  
   $command = 'tabix -p vcf ' . escapeshellarg($format_tmp) . '.gz';
   drush_print(shell_exec($command));
   drush_print(str_repeat('-', 60));
-  
-  $command = 'tar cvf ' . escapeshellarg($format_tmp) . '.tar ' . escapeshellarg($format_tmp) . '.gz ' . escapeshellarg($format_tmp) . '.gz.tbi';
+  drush_print('File generated is: '.$format_tmp.'.gz.tbi');
+  $command = 'tar cvf '.escapeshellarg($format_tmp).'.tar'.' -C '.escapeshellarg($bgzip_tmp_path).' '.escapeshellarg($bgzip_filename).'.gz '.escapeshellarg($bgzip_filename).'.gz.tbi';
   drush_print(shell_exec($command));
   drush_print(str_repeat('-', 60));
+  drush_print('File generated is: '.$format_tmp.'tar');
   
   if (!file_exists($outfile)) {
-    drush_set_error("ERROR: Unable to convert VCF file to zipped '.gz & .gz.tbi' format.");
+    drush_set_error("ERROR: Unable to convert VCF file to an archive file (.tar).");
     exit(4); // We use exit to trigger a Tripal job error b/c Tripal doesn't check the return code :-(.
   }
   
   // Tell the user we're almost there!
-  tripal_set_job_progress($job_id, 90);
+  tripal_set_job_progress($job_id, 90);                                                                                          
   drush_print("\nMove Formatted file to the name we expect.");
   shell_exec("mv $format_tmp.tar $filepath");
   if (!file_exists($filepath)) {
@@ -86,3 +95,4 @@ function vcf_filter_bgzipped_generate_file($variables, $job_id = NULL) {
   // Done!
  tripal_set_job_progress($job_id, 100);
 }
+  

--- a/includes/vcf_filter.trpdownload.bgzipped.inc
+++ b/includes/vcf_filter.trpdownload.bgzipped.inc
@@ -66,11 +66,11 @@ function vcf_filter_bgzipped_generate_file($variables, $job_id = NULL) {
  
   $bgzip_tmp_path = variable_get('file_temporary_path');
   
-  drush_print('Useing bgzip to generate bgzip file: '.$format_tmp.'.gz');
+  drush_print('Using bgzip to generate bgzipped file: '.$format_tmp.'.gz');
   $command = 'bgzip -c ' . escapeshellarg($filtered_vcf) . ' > ' . escapeshellarg($format_tmp) . '.gz';
   drush_print(shell_exec($command));
   
-  drush_print('Useing tabix to generate index file: '.$format_tmp.'.gz.tbi');
+  drush_print('Using tabix to generate index file: '.$format_tmp.'.gz.tbi');
   $command = 'tabix -p vcf ' . escapeshellarg($format_tmp) . '.gz';
   drush_print(shell_exec($command));
   
@@ -86,7 +86,7 @@ function vcf_filter_bgzipped_generate_file($variables, $job_id = NULL) {
   // Tell the user we're almost there!
   tripal_set_job_progress($job_id, 90);  
   
-  drush_print("\nMove Formatted file to the name we expect.");
+  drush_print("Move formatted file to the name we expect.");
   shell_exec("mv $format_tmp.tar $filepath");
   
   if (!file_exists($filepath)) {
@@ -96,4 +96,3 @@ function vcf_filter_bgzipped_generate_file($variables, $job_id = NULL) {
   // Done!
   tripal_set_job_progress($job_id, 100);
 }
-  

--- a/includes/vcf_filter.trpdownload.bgzipped.inc
+++ b/includes/vcf_filter.trpdownload.bgzipped.inc
@@ -1,0 +1,88 @@
+<?php
+/**
+ * @file
+ * Handles download of VCF files in bgzipped Format for use in R package (VariantAnnotation).
+ */
+/**
+ * Generate bgzipped File from VCF.
+ *
+ * @param $variables
+ *   An associative array of parameters including:
+ *     - q: all the query paramters.
+ *     - site_safe_name: a sanitized version of your site name for use in variables & filenames.
+ *     - type_info: an array of info for the download type.
+ *     - suffix: the file format suffix.
+ *     - filename: the filename of the file to generate not including path.
+ *     - fullpath: the full path and filename of the file to generate.
+ *     - format_name: a human-readable description of the format.
+ * @param $job_id
+ *   The ID of the tripal job executing this function ;-).
+ */
+function vcf_filter_bgzipped_generate_file($variables, $job_id = NULL) {
+  // Create the file and ready it for writting to.
+  $filepath = variable_get('trpdownload_fullpath', '') . $variables['filename'];
+  drush_print("File: " . $filepath);
+  // Get the VCF file details.
+  $vcf_file = vcf_filter_get_vcf_file($variables['q']['vcf_file_id']);
+  drush_print("\nVCF File (".$vcf_file->name."): ".$vcf_file->file_path);
+  // Check the input file still exists.
+  if (!file_exists($vcf_file->file_path)) {
+    drush_set_error("ERROR: Original VCF file not found!");
+    exit(2);
+  }
+  // Print out parameters.
+  drush_print("Parameters:");
+  foreach ($variables['q'] as $label => $value) {
+    drush_print('  ' . $label . ': ' . $value);
+  }
+  // Give the user some indication we've done something...
+  tripal_set_job_progress($job_id, 5);
+  // Filter.
+  //===============
+  drush_print("\nFiltering the Original VCF");
+  $filtered_vcf = vcf_filter_filter_file($vcf_file->file_path, $variables['q']);
+  if (!$filtered_vcf) {
+    exit(3);
+  }
+  // Half way point...
+  tripal_set_job_progress($job_id, 50);
+  // FORMAT.
+  //===============
+  drush_print("\nConversion from VCF to bgzipped VCF Format.");
+  $format_tmp = variable_get('file_temporary_path') . '/' . uniqid();
+  $outfile = $format_tmp . '.tar';
+  drush_print('Converted results will be in: '.$outfile);
+  drush_print(str_repeat('-', 60));
+  /*Creating a compressed and indexed VCF
+    bgzip -c file.vcf > file.vcf.gz
+    tabix -p vcf file.vcf.gz
+    tar cvf archive.tar file.vcf.gz file.vcf.gz.tbi
+  */
+  //$command = 'vcftools --vcf ' . escapeshellarg($filtered_vcf) . ' --geno-depth --out ' . escapeshellarg($format_tmp);
+  $command = 'bgzip -c ' . escapeshellarg($filtered_vcf) . ' > ' . escapeshellarg($format_tmp) . '.gz';
+  drush_print(shell_exec($command));
+  drush_print(str_repeat('-', 60));
+  $command = 'tabix -p vcf ' . escapeshellarg($format_tmp) . '.gz';
+  drush_print(shell_exec($command));
+  drush_print(str_repeat('-', 60));
+  
+  $command = 'tar cvf ' . escapeshellarg($format_tmp) . '.tar ' . escapeshellarg($format_tmp) . '.gz ' . escapeshellarg($format_tmp) . '.gz.tbi';
+  drush_print(shell_exec($command));
+  drush_print(str_repeat('-', 60));
+  
+  if (!file_exists($outfile)) {
+    drush_set_error("ERROR: Unable to convert VCF file to zipped '.gz & .gz.tbi' format.");
+    exit(4); // We use exit to trigger a Tripal job error b/c Tripal doesn't check the return code :-(.
+  }
+  
+  // Tell the user we're almost there!
+  tripal_set_job_progress($job_id, 90);
+  drush_print("\nMove Formatted file to the name we expect.");
+  shell_exec("mv $format_tmp.tar $filepath");
+  if (!file_exists($filepath)) {
+    drush_set_error("ERROR: Unable to move Filtered VCF into expected file director: $filepath");
+    exit(5); // We use exit to trigger a Tripal job error b/c Tripal doesn't check the return code :-(.
+  }
+  // Done!
+ tripal_set_job_progress($job_id, 100);
+}

--- a/includes/vcf_filter.trpdownload.inc
+++ b/includes/vcf_filter.trpdownload.inc
@@ -65,8 +65,8 @@ function vcf_filter_register_trpdownload_type() {
 
   return $types;
 }
-/*
+
+//since the file we want to export is an archive, so the extension is set as .tar
 function vcf_filter_tar_extension ($vars){
   return 'tar';
 }
-*/

--- a/includes/vcf_filter.trpdownload.inc
+++ b/includes/vcf_filter.trpdownload.inc
@@ -13,7 +13,8 @@ require_once('vcf_filter.trpdownload.matrix.inc');
 require_once('vcf_filter.trpdownload.qual_matrix.inc');
 // Basic VCF.
 require_once('vcf_filter.trpdownload.vcf.inc');
-
+// Bgzipped VCF file
+require_once('vcf_filter.trpdownload.bgzipped.inc');
 /**
  * Implements hook_register_trpdownload_type().
  */
@@ -53,5 +54,19 @@ function vcf_filter_register_trpdownload_type() {
     ),
   );
 
+  $types['vcf_filter_bgzipped'] = array(
+    'type_name' => 'VCF Filter',
+    'format' => 'Bgzipped VCF Format',
+    'functions' => array(
+      'generate_file' => 'vcf_filter_bgzipped_generate_file',
+      'get_file_suffix' => 'vcf_filter_tar_extension',
+    ),
+  );
+
   return $types;
 }
+
+function vcf_filter_tar_extension ($vars){
+  return 'tar';
+}
+

--- a/includes/vcf_filter.trpdownload.inc
+++ b/includes/vcf_filter.trpdownload.inc
@@ -65,8 +65,8 @@ function vcf_filter_register_trpdownload_type() {
 
   return $types;
 }
-
+/*
 function vcf_filter_tar_extension ($vars){
   return 'tar';
 }
-
+*/

--- a/vcf_filter.module
+++ b/vcf_filter.module
@@ -56,7 +56,7 @@ function vcf_filter_menu() {
   );
 
   $items['filter_vcf/Bgzipped'] = array(
-    'title' => 'Download Filtered VCF: Bgzipped VCF',
+    'title' => 'Download Filtered VCF: Block Compression/Decompression (bgzipped) Format',
     'page callback' => 'trpdownload_download_page',
     'page arguments' => array('vcf_filter_bgzipped'),
     'access arguments' => array('access content'),

--- a/vcf_filter.module
+++ b/vcf_filter.module
@@ -55,6 +55,15 @@ function vcf_filter_menu() {
     'type' => MENU_CALLBACK,
   );
 
+  $items['filter_vcf/Bgzipped'] = array(
+    'title' => 'Download Filtered VCF: Bgzipped VCF',
+    'page callback' => 'trpdownload_download_page',
+    'page arguments' => array('vcf_filter_bgzipped'),
+    'access arguments' => array('access content'),
+    'type' => MENU_CALLBACK,
+  );
+
+
   // ADMINISTRATION.
   // List VCF Files.
   $items['admin/tripal/extension/vcf_filter'] = array(


### PR DESCRIPTION
The purpose of this work is allowing user to have another option (bgzipped VCF format) in picking Export Format  when use VCF Bulk on Knowpulse. 
In total of 3 modified files (vcf_filter.module && includes/vcf_filter.form.inc && includes/vcf_filter.trpdownload.inc) and one new file (includes/vcf_filter.trpdownload.bgzipped.inc). 

There are only minor changes and hopefully its readable for review.