### PR TITLE
16 maf mmc mmf description update

### DIFF
--- a/includes/vcf_filter.form.inc
+++ b/includes/vcf_filter.form.inc
@@ -114,21 +114,21 @@ function vcf_filter_form($form, &$form_state) {
   $form['s2']['minor_allele_freq'] = array(
     '#type' => 'textfield',
     '#title' => 'Minor Allele Frequency',
-    '#description' => 'Only include SNP positions with a minor allele frequency greater than or equal to this value. Allele frequency is defined as the number of times an allele appears over all individuals at that site, divided by the total number of non-missing alleles at that site. For example, consider Chr1p12344 in the example table below: the minor allele frequency for A is 2/5=40%, thus if you enter 50% this SNP position will be removed.',
+    '#description' => 'Only include SNP positions with a minor allele frequency greater than or equal to this value. Allele frequency is defined as the number of times an allele appears over all individuals at that site, divided by the total number of non-missing alleles at that site. For example, if your enter 45% in this filter then SNPs with minor allele frequency lower than 45% could be removed (SNP Chr1p12344 in the example data below).',
     '#default_value' => '',
   );
 
   $form['s2']['max_missing_count'] = array(
     '#type' => 'textfield',
     '#title' => 'Maximum Missing Count',
-    '#description' => 'Exclude SNPs with more than this number of missing genotypes over all individuals/germplasm. For example, if you enter 1 for this filter for the example data below, only SNP Chr4p48765 would be removed.',
+    '#description' => 'Exclude SNPs with more than this number of missing genotypes over all individuals/germplasm. For example, if you enter 1 for this filter then SNPs with more than 1 missing genotype would be removed (SNP Chr4p48765 in the example data below).',
     '#default_value' => '',
   );
 
   $form['s2']['max_missing_freq'] = array(
     '#type' => 'textfield',
     '#title' => 'Maximum Missing Frequency',
-    '#description' => 'Exclude SNPs based on the proportion of missing data. For example, if you enter 25% for this filter then for the example data below, only SNP Chr4p48765 would be removed since it has a missing data frequency of 2/6=33%.',
+    '#description' => 'Exclude SNPs based on the proportion of missing data. For example, if you enter 25% for this filter then SNPs with a missing data frequence higher than 25% would be removed (SNP Chr4p48765 in the example data below).',
     '#default_value' => '',
   );
 

--- a/includes/vcf_filter.form.inc
+++ b/includes/vcf_filter.form.inc
@@ -114,7 +114,7 @@ function vcf_filter_form($form, &$form_state) {
   $form['s2']['minor_allele_freq'] = array(
     '#type' => 'textfield',
     '#title' => 'Minor Allele Frequency',
-    '#description' => 'Only include SNP positions with a minor allele frequency greater than or equal to this value. Allele frequency is defined as the number of times an allele appears over all individuals at that site, divided by the total number of non-missing alleles at that site. For example, if your enter 45% in this filter then SNPs with minor allele frequency lower than 45% could be removed (SNP Chr1p12344 in the example data below).',
+    '#description' => 'Only include SNP positions with a minor allele frequency greater than or equal to this value. Allele frequency is defined as the number of times an allele appears over all individuals at that site, divided by the total number of non-missing alleles at that site. For example, if your enter 45% in this filter then SNPs with a minor allele frequency lower than 45% could be removed (SNP Chr1p12344 in the example data below).',
     '#default_value' => '',
   );
 
@@ -128,7 +128,7 @@ function vcf_filter_form($form, &$form_state) {
   $form['s2']['max_missing_freq'] = array(
     '#type' => 'textfield',
     '#title' => 'Maximum Missing Frequency',
-    '#description' => 'Exclude SNPs based on the proportion of missing data. For example, if you enter 25% for this filter then SNPs with a missing data frequence higher than 25% would be removed (SNP Chr4p48765 in the example data below).',
+    '#description' => 'Exclude SNPs based on the proportion of missing data. For example, if you enter 25% for this filter then SNPs with a missing data frequency higher than 25% would be removed (SNP Chr4p48765 in the example data below).',
     '#default_value' => '',
   );
 


### PR DESCRIPTION
update description of minor allele frequency to:
'Only include SNP positions with a minor allele frequency greater than or equal to this value. Allele frequency is defined as the number of times an allele appears over all individuals at that site, divided by the total number of non-missing alleles at that site. For example, if your enter 45% in this filter then SNPs with a minor allele frequency lower than 45% could be removed (SNP Chr1p12344 in the example data below).'

update description of maximun missing count to:
'Exclude SNPs with more than this number of missing genotypes over all individuals/germplasm. For example, if you enter 1 for this filter then SNPs with more than 1 missing genotype would be removed (SNP Chr4p48765 in the example data below).'

update description of maximun missing frequency to: 
'Exclude SNPs based on the proportion of missing data. For example, if you enter 25% for this filter then SNPs with a missing data frequency higher than 25% would be removed (SNP Chr4p48765 in the example data below).'