### PR TITLE
Fixed the filter criteria maximum missing count by multiplying user-supplied value by 2

### DIFF
--- a/api/vcf_filter.api.inc
+++ b/api/vcf_filter.api.inc
@@ -132,7 +132,10 @@ function vcf_filter_filter_file($file_path, $filter_criteria, $drush_use_limited
 
   // Maximum Missing Count:
   if (!empty($filter_criteria['max_missing_count'])) {
-    $command .= ' --max-missing-count ' . escapeshellarg($filter_criteria['max_missing_count']);
+    // Multiply the user’s value by 2 because vcftools counts individual alleles rather than the combined diploid genotype call
+    // @ASSUMPTION: This module only deals with diploid organisms
+    $max_missing_count = $filter_criteria['max_missing_count'] * 2;
+    $command .= ' --max-missing-count ' . escapeshellarg($max_missing_count);
   }
 
   // Maximum Missing Count:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- No need to include the issue number in the title :-) -->

## Metadata
<!--- If it fixes an open issue, please add the issue link below. -->
 - Issue #

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I feel this PR is ready to be merged.
- [ ] This PR is dependent upon [PR #/ nothing]

Documentation:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
We recently discovered that the "max missing count" parameter yielded different results than expected. The description in the vcftools manual reads:
> Exclude sites with more than this number of missing genotypes over all individuals.

I was interpreting a single call as, for example, "AA" when vcftools seems to treat each allele as a separate call for diploid organisms. Thus, based on our description in the input form for this parameter, users would assume the maximum number of genotypes for a site equals the number of individuals, when in reality the true maximum is double the number of individuals.

Rather than altering our description for max missing count to the user, I opted for taking their value and doubling it behind the scenes. One limitation of this is that this module will only deal with diploid organisms.

## Testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how
      your change affects other areas of the code, etc. -->
<!--- Reviewers will use this section to test the submission! -->
A simple test case without resorting to statistically comparing a file before and after filtering is to filter for half the number of individuals which should be the equivalent of a max missing frequency of 50%.
1. On Fresh, first choose a file to test that has not had significant filtering done to it (for example, NOT the UCD GBS Radseq set) and note the number of individuals in the description (ideally an even number).
2. Divide the number in half and enter it in the max missing count field. Choose the VCF output format and submit the job.
3. Note the job output on the terminal. 
   - The parameters list should reflect the value put into the form for max missing count
   - The vcftools command that was run should include `--max-missing-count '###'` where the number is double the value you provided in the form.
   - Observe the number of sites kept. For ex, `After filtering, kept 980 out of a possible 2467 Sites`
4. Re-submit the job after replacing your value in max missing count with "50" for max missing frequency.
5. Verify that the number of sites kept is the same.

- [ ] I tested on a generic Tripal Site
- [x] I tested on a KnowPulse Clone
- [ ] This PR includes automated testing
